### PR TITLE
Revert "tmp exclusion on RNE login 4"

### DIFF
--- a/src/utils/auth/api-rne/index.ts
+++ b/src/utils/auth/api-rne/index.ts
@@ -31,7 +31,7 @@ class RNEClient {
             [process.env.RNE_LOGIN, process.env.RNE_PASSWORD],
             [process.env.RNE_LOGIN_2, process.env.RNE_PASSWORD_2],
             [process.env.RNE_LOGIN_3, process.env.RNE_PASSWORD_3],
-            // [process.env.RNE_LOGIN_4, process.env.RNE_PASSWORD_4],
+            [process.env.RNE_LOGIN_4, process.env.RNE_PASSWORD_4],
           ];
   }
 


### PR DESCRIPTION
Reverts annuaire-entreprises-data-gouv-fr/api-proxy#34
depends on https://github.com/annuaire-entreprises-data-gouv-fr/infrastructure/pull/264