### PR TITLE
chore: temp disabling RNE access through API

### DIFF
--- a/src/controllers/rne.ts
+++ b/src/controllers/rne.ts
@@ -10,7 +10,6 @@ export const rneControllerAPI = async (
   try {
     const siren = verifySiren(req.params.siren);
     const rne = await fetchRneAPI(siren);
-
     res.status(200).json(rne);
   } catch (e) {
     next(e);


### PR DESCRIPTION
Unfortunately account renewal was not enough and account just got banned