### PR TITLE
feat: add new RNE observations

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: ${{ env.node-version }}
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: restore-dependencies
         env:
           cache-name: cache-node-modules

--- a/src/clients/inpi/api-rne/interface.ts
+++ b/src/clients/inpi/api-rne/interface.ts
@@ -165,9 +165,17 @@ export interface IRNEResponse {
         entrepriseAgricole: boolean;
         eirl: boolean;
       };
+      inscriptionsOffices: [];
       personneMorale?: IRNEPersonneMorale;
       exploitation?: IRNEPersonneMorale;
       personnePhysique?: IRNEPersonnePhysique;
     };
   };
 }
+
+export type IRNEInscriptionsOffices = {
+  dateEffet: string;
+  partnerCenter: string;
+  partnerCode: string;
+  observationComplementaire: string;
+};


### PR DESCRIPTION
- we use to only display observations extracted from old RCS
- turns out RNE store observations in `inscriptionsOffices` field

Still unsure we have every old observations : 
- are there old observation for RNM ? RAA and what about personnePhysique ? 

Will ask to Maelle right after we merge this

https://documentation.beta.numerique.gouv.fr/doc/observations-au-rne-x8vX2POg6p